### PR TITLE
Evitare flame sotto gli annunci di lavoro

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -115,6 +115,14 @@ Voci consigliate:
 - Indica una forbice retributiva (il minimo è obbligatorio come specificato in precedenza)
 - Indica se è possibile lavorare da remoto
 
+Così come è obbligatorio, per chi offre lavoro, il rispetto del regolamento allo stesso modo chi non è interessato all'annuncio può evitare di scrivere commenti che lasciano il tempo che trovano. La civiltà deve essere mantenuta da entrambe le parti. Esempi di commenti che verranno cancellati:
+
+- "l'offerta è troppo bassa"
+- "non troverete mai chi cercate"
+- battute e ironia varia
+
+Se un admin rileverà che questo comportamento dovesse essere portato avanti più di una volta da quell'utente (esattamente come già avviene per chi mette annunci non compatibili) i commenti verranno cancellati e in casi più gravi l'utente espulso dal gruppo.
+
 Di seguito vi mettiamo a disposizione un template per iniziare il post nella maniera migliore:
 
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -119,7 +119,7 @@ Così come è obbligatorio il rispetto del regolamento per chi offre lavoro, all
 
 - "l'offerta è troppo bassa"
 - "non troverete mai chi cercate"
-- battute e ironia varia
+- battute o commenti ironici che non portano nulla di concreto alla discussione
 
 Se un admin rileverà che questo comportamento dovesse essere portato avanti più di una volta da quell'utente (esattamente come già avviene per chi mette annunci non compatibili) i commenti verranno cancellati e in casi più gravi l'utente espulso dal gruppo.
 

--- a/Readme.md
+++ b/Readme.md
@@ -115,7 +115,7 @@ Voci consigliate:
 - Indica una forbice retributiva (il minimo è obbligatorio come specificato in precedenza)
 - Indica se è possibile lavorare da remoto
 
-Così come è obbligatorio, per chi offre lavoro, il rispetto del regolamento allo stesso modo chi non è interessato all'annuncio può evitare di scrivere commenti che lasciano il tempo che trovano. La civiltà deve essere mantenuta da entrambe le parti. Esempi di commenti che verranno cancellati:
+Così come è obbligatorio il rispetto del regolamento per chi offre lavoro, allo stesso modo chi non è interessato all'annuncio può evitare di scrivere risposte inopportune. La civiltà deve essere mantenuta da entrambe le parti. Esempi di commenti che verranno cancellati:
 
 - "l'offerta è troppo bassa"
 - "non troverete mai chi cercate"


### PR DESCRIPTION
Che ne pensate?

Abbiamo messo regole abbastanza strette (e giuste) per chi posta annunci di lavoro, con l'obiettivo di aggiungere valore alla discussione e all'offerta. Direi di fare la stessa cosa per chi commenta tali post, per par condicio.